### PR TITLE
Refactor header/drawer and BrewList UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,10 +24,10 @@ function HomebrewExplorer() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-[#111] text-gray-900 dark:text-gray-100 p-4 sm:p-8 transition-colors">
       <div className="max-w-7xl mx-auto space-y-8">
-        <NavDrawer isOpen={isOpen} onClose={() => setIsOpen(false)} onShowInstallGuide={() => setIsOpen(true)} />
+        <NavDrawer isOpen={isOpen} onClose={() => setIsOpen(false)} />
 
         {/* HEADER */}
-        <Header type={type} search={search} setSearch={setSearch} setIsOpen={setIsOpen} />
+        <Header setIsOpen={setIsOpen} />
         <Routes>
           <Route path="/install" element={<div>Install Guide</div>} />
           {/* <BrewList search={search} setSearch={setSearch} type={type} setType={setType} /> */}

--- a/src/components/layout/Drawer.tsx
+++ b/src/components/layout/Drawer.tsx
@@ -7,8 +7,7 @@ import { NavLink } from "react-router-dom";
 interface NavDrawerProps {
     isOpen: boolean;
     onClose: () => void;
-    // Callback to tell the parent (Header) to open the Modal
-    onShowInstallGuide: () => void;
+
 }
 
 // Internal component for clean link rendering
@@ -25,7 +24,7 @@ const DrawerLink = ({ href, icon: Icon, name, onClose }: { href: string; icon: a
     </a>
 );
 
-export const NavDrawer = ({ isOpen, onClose, onShowInstallGuide }: NavDrawerProps) => {
+export const NavDrawer = ({ isOpen, onClose }: NavDrawerProps) => {
 
     // Link Definitions
     const externalLinks = [
@@ -42,7 +41,7 @@ export const NavDrawer = ({ isOpen, onClose, onShowInstallGuide }: NavDrawerProp
         >
             {/* Backdrop: Closes the drawer when clicking outside */}
             <div
-                className="absolute inset-0 h-[100vh] bg-black/80"
+                className="absolute inset-0 h-screen bg-black/80"
                 onClick={onClose}
             />
 
@@ -71,11 +70,11 @@ export const NavDrawer = ({ isOpen, onClose, onShowInstallGuide }: NavDrawerProp
                     {/* Action Button: Installation Details */}
                     <NavLink
                         to={`/installation`}
+                        onClick={onClose}
                     >
                         <Button
                             className="flex w-full justify-start font-bold py-3 text-base"
                             variant="primary"
-                            onClick={onShowInstallGuide} // Triggers the modal open logic in the parent
                         >
                             <Terminal className="w-5 h-5 mr-3" />
                             <span>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,17 +1,14 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/Button";
-import { MenuIcon, Terminal, Search, Moon, Sun } from "lucide-react";
+import { MenuIcon, Terminal, Moon, Sun } from "lucide-react";
 import { NavLink } from "react-router-dom";
 
 
 interface HeaderProps {
-  type: string;
-  search: string;
-  setSearch: (value: string) => void;
   setIsOpen: (value: boolean) => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ type, search, setSearch, setIsOpen }) => {
+export const Header: React.FC<HeaderProps> = ({ setIsOpen }) => {
   const [theme, setTheme] = useState(
     () => localStorage.getItem("theme") || "light",
   );
@@ -22,7 +19,7 @@ export const Header: React.FC<HeaderProps> = ({ type, search, setSearch, setIsOp
   }, [theme]);
 
   return (
-    <header className="flex flex-col md:flex-row gap-4 justify-between items-center">
+    <header className="flex  gap-4 justify-between items-center">
       <div className="flex items-center gap-3">
         <Button variant="ghost"
           onClick={() => setIsOpen(true)}
@@ -30,22 +27,13 @@ export const Header: React.FC<HeaderProps> = ({ type, search, setSearch, setIsOp
           <MenuIcon size={20} />
         </Button>
         <NavLink to="/brewlens" className="flex items-center gap-2 text-gray-600 dark:text-gray-100 hover:text-gray-800 dark:hover:text-gray-200">
-            <Terminal size={20} className="bg-green-600 text-white p-1.5 w-8 h-8 rounded-md" />
+          <Terminal size={20} className="bg-green-600 text-white p-1.5 w-8 h-8 rounded-md" />
           <h1 className="text-3xl my-auto font-bold">
             Brew<span className="font-light opacity-70">Lens</span>
           </h1>
         </NavLink>
       </div>
-      <div className="flex gap-3 w-full md:w-auto">
-        <div className="relative flex-1 md:w-80">
-          <Search className="absolute left-3 top-3 text-gray-400" size={18} />
-          <input
-            className="w-full pl-10 pr-4 py-2 rounded-lg bg-white dark:bg-zinc-800 border border-gray-200 dark:border-gray-700 focus:ring-2 focus:ring-green-500 outline-none"
-            placeholder={`Search ${type}s...`}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-        </div>
+      <div className="flex gap-3 w-12">
         <Button
           variant="ghost"
           onClick={() => setTheme((t) => (t === "light" ? "dark" : "light"))}

--- a/src/components/page/BrewList.tsx
+++ b/src/components/page/BrewList.tsx
@@ -7,6 +7,7 @@ import { Button } from "../ui/Button";
 import { cn } from '../../lib/utils';
 import { type BrewType } from "../../types";
 import SkeletonGrid from "./SkeletonGrid";
+import { Search, X } from "lucide-react";
 
 interface Props {
     type: BrewType;
@@ -30,24 +31,36 @@ export const BrewList: React.FC<Props> = ({ type, setType, search, setSearch }) 
     const { currentData, currentPage, setCurrentPage, totalPages } = usePagination(filtered, itemsPerPage);
 
     {/* CONTROLS */ }
-    return <>
-        <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
-            <div className="bg-gray-200 dark:bg-zinc-800 p-1 rounded-lg flex">
-                {(['cask', 'formula'] as const).map(t => (
-                    <button
-                        key={t}
-                        onClick={() => { setType(t); setSearch(''); }}
-                        className={cn("px-4 py-1.5 rounded-md text-sm font-medium capitalize transition-all",
-                            type === t ? "bg-white dark:bg-zinc-600 shadow text-green-600 dark:text-green-400" : "text-gray-500"
-                        )}
-                    >
-                        {t}s
-                    </button>
-                ))}
+    return <div className="contasiner max-w-[1400px] mx-auto">
+        <div className="flex flex-col sm:flex-row justify-between items-center gap-4 mb-8">
+            <div className="w-full flex flex-wrap justify-left gap-2">
+                <div className="relative w-full max-w-[20rem]">
+                    <Search className="absolute left-3 top-3 text-gray-400" size={18} />
+                    <input
+                        className="w-full minz-w-80 pl-10  pr-10 py-2 rounded-lg bg-white dark:bg-zinc-800 border border-gray-200 dark:border-gray-700 focus:ring-2 focus:ring-green-500 outline-none"
+                        placeholder={`Search...`}
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                    />
+                    {search && <X className="absolute right-3 top-3 text-gray-400 bg-zinc-300/10 hover:bg-zinc-300 p-[2px] rounded-full cursor-pointer" size={18} onClick={() => setSearch("")} />}
+                </div>
+                <div className="bg-gray-200 dark:bg-zinc-800 p-1 rounded-lg flex">
+                    {(['cask', 'formula'] as const).map(t => (
+                        <button
+                            key={t}
+                            onClick={() => { setType(t); setSearch(''); }}
+                            className={cn("px-4 py-1.5 rounded-md text-sm font-medium capitalize transition-all",
+                                type === t ? "bg-white dark:bg-zinc-600 shadow text-green-600 dark:text-green-400" : "text-gray-500"
+                            )}
+                        >
+                            {t}s
+                        </button>
+                    ))}
+                </div>
             </div>
 
             {totalPages > 1 && (
-                <div className="flex items-center gap-3 text-sm">
+                <div className="flex items-center gap-3 text-sm min-w-40">
                     <span className="text-gray-500">Items per page:</span>
                     <select
                         className="bg-transparent font-medium cursor-pointer outline-none"
@@ -61,31 +74,32 @@ export const BrewList: React.FC<Props> = ({ type, setType, search, setSearch }) 
         </div>
 
         {/* GRID */}
-        {
-            isLoading ? (
-                <SkeletonGrid count={itemsPerPage} />
-            ) : error ? (
-                <div className="py-20 text-center text-red-500">Failed to load data.</div>
-            ) : (
-                <>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-                        {currentData.map(item => (
-                            <ItemCard key={item.id} item={item} />
-                        ))}
-                    </div>
+        {isLoading && <SkeletonGrid count={itemsPerPage} />}
+        {error && <div className="py-20 text-center text-red-500">Failed to load data.</div>}
+        {currentData && <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {currentData.map(item => (
+                    <ItemCard key={item.id} item={item} />
+                ))}
+            </div>
 
-                    {/* PAGINATION */}
-                    {totalPages > 1 && (
-                        <div className="flex justify-center gap-4 pt-8">
-                            <Button variant="secondary" disabled={currentPage === 1} onClick={() => setCurrentPage(currentPage - 1)}>Prev</Button>
-                            <span className="py-2 text-sm font-mono text-zinc-500">Page {currentPage} of {totalPages}</span>
-                            <Button variant="secondary" disabled={currentPage === totalPages} onClick={() => setCurrentPage(currentPage + 1)}>Next</Button>
-                        </div>
-                    )}
+            {/* PAGINATION */}
+            {totalPages > 1 && (
+                <div className="flex justify-center gap-4 pt-8">
+                    <Button variant="secondary" disabled={currentPage === 1} onClick={() => setCurrentPage(currentPage - 1)}>Prev</Button>
+                    <span className="py-2 text-sm font-mono text-zinc-500">Page {currentPage} of {totalPages}</span>
+                    <Button variant="secondary" disabled={currentPage === totalPages} onClick={() => setCurrentPage(currentPage + 1)}>Next</Button>
+                </div>
+            )}
 
-                </>
-            )
-        }
-    </>
+        </>}
+        {currentData.length === 0 && <>
+            <div className="h-120 flex flex-col items-center justify-center p-20 text-gray-500">
+                <Search className="mb-4 h-12 w-12 opacity-40 text-zinc-800 dark:text-zinc-100" />
+                <p className="text-lg">No data found. Try something else?</p>
+            </div>
+        </>}
+
+    </div>
 
 };

--- a/src/components/page/CaskDetail.tsx
+++ b/src/components/page/CaskDetail.tsx
@@ -62,9 +62,9 @@ export function CaskDetail() {
   const sha256 = raw.sha256 || "Not available";
 
   return (
-    <div className="min-h-screen p-8 text-gray-800 dark:text-gray-200 font-sans">
+    <div className="min-h-screen p-2  text-gray-800 dark:text-gray-200 font-sans max-[1400px] mx-auto">
       {/* Top Navigation Bar */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between  mb-4">
         <NavLink
           to={`/brewlens`}
         >

--- a/src/components/page/FormulaeDetail.tsx
+++ b/src/components/page/FormulaeDetail.tsx
@@ -48,9 +48,8 @@ export const FormulaeDetail = () => {
 
 
     return (
-        <div className="min-h-screen text-zinc-800 dark:text-zinc-100 p-4 md:p-8 font-sans">
-            <div className="max-w-6xl mx-auto space-y-6">
-
+        <div className="min-h-screen text-zinc-800 dark:text-zinc-100 p-2 font-sans">
+            <div className="max-[1400px] mx-auto space-y-6">
                 {/* Top Navigation Bar */}
                 <div className="flex items-center justify-between mb-4">
                     <NavLink


### PR DESCRIPTION
Remove search-related props from Header and simplify NavDrawer API (drop onShowInstallGuide). NavDrawer now uses h-screen for backdrop and closes on navigation. Header no longer renders the global search input and only exposes setIsOpen and theme toggle. Rework BrewList layout: add integrated search input with clear (X) button, reorganize filters, improve responsive container/styles, and simplify loading/error/grid rendering while preserving pagination. Also tweak spacing/padding and max-width wrappers in CaskDetail and FormulaeDetail for better responsiveness.