### PR TITLE
Add bookmarks, recents, Brewfile, and dashboard, fix copy state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 test*
+.kiro

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Modal } from './components/ui/Modal';
 import { ModalProvider } from './components/contexts/ModalContexts';
+import { BookmarksProvider } from './components/contexts/BookmarksContext';
+import { RecentlyViewedProvider } from './components/contexts/RecentlyViewedContext';
 import { NavDrawer } from './components/layout/Drawer';
 import { Header } from './components/layout/Header';
 import { BrewList } from './components/page/BrewList';
@@ -13,6 +15,7 @@ import Installation from './components/page/Installation';
 import FormulaeDetail from './components/page/FormulaeDetail';
 import About from './components/page/About';
 import Analytics from './components/page/Analytics';
+import Dashboard from './components/page/Dashboard';
 
 const queryClient = new QueryClient();
 
@@ -31,7 +34,8 @@ function HomebrewExplorer() {
         <Routes>
           <Route path="/install" element={<div>Install Guide</div>} />
           {/* <BrewList search={search} setSearch={setSearch} type={type} setType={setType} /> */}
-          <Route path="/" element={<BrewList search={search} setSearch={setSearch} type={type} setType={setType} />} />
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/all" element={<BrewList search={search} setSearch={setSearch} type={type} setType={setType} />} />
           <Route path="/installation" element={<Installation />} />
           <Route path="/cask/:token" element={<CaskDetail />} />
           <Route path="/formula/:token" element={<FormulaeDetail />} />
@@ -49,8 +53,12 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ModalProvider>
-        <HomebrewExplorer />
-        <Modal />
+        <BookmarksProvider>
+          <RecentlyViewedProvider>
+            <HomebrewExplorer />
+            <Modal />
+          </RecentlyViewedProvider>
+        </BookmarksProvider>
       </ModalProvider>
     </QueryClientProvider>
   );

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -20,7 +20,7 @@ export const ItemCard = memo(({ item }: { item: BrewItem }) => {
         <NavLink
             to={`/${item.type}/${item.token}`}
         >
-            <div className="flex flex-col p-4 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-2xl hover:shadow-lg hover:border-green-500 transition-all h-full group">
+            <div className="flex flex-col p-4 bg-white dark:bg-zinc-900/70 border border-gray-200 dark:border-zinc-800 rounded-2xl hover:shadow-lg hover:border-green-500 transition-all h-full group">
                 <div className="flex gap-4 items-start mb-3 ">
                     <img
                         src={`https://www.google.com/s2/favicons?domain=${item.homepage}&sz=64`}

--- a/src/components/contexts/BookmarksContext.tsx
+++ b/src/components/contexts/BookmarksContext.tsx
@@ -1,0 +1,97 @@
+/**
+ * @file BookmarksContext.tsx
+ * Provides bookmark/collection management with localStorage persistence.
+ */
+
+import { createContext, useContext, type ReactNode } from 'react';
+import { useStorage } from '../../hooks/useStorage';
+import type { BrewItem } from '../../types';
+
+export interface Collection {
+    id: string;
+    name: string;
+    itemIds: string[];
+}
+
+export interface BookmarksContextType {
+    collections: Collection[];
+    addCollection: (name: string) => void;
+    removeCollection: (id: string) => void;
+    renameCollection: (id: string, name: string) => void;
+    toggleBookmark: (collectionId: string, item: BrewItem) => void;
+    isBookmarked: (itemId: string) => boolean;
+    getCollectionForItem: (itemId: string) => Collection | undefined;
+}
+
+const BookmarksContext = createContext<BookmarksContextType | null>(null);
+
+const DEFAULT_COLLECTION: Collection = { id: 'favourites', name: 'Favourites', itemIds: [] };
+
+function isValidName(name: string): boolean {
+    return name.trim().length > 0 && name.length <= 50;
+}
+
+export function BookmarksProvider({ children }: { children: ReactNode }) {
+    const [rawCollections, setCollections] = useStorage<Collection[]>('brewlens_bookmarks', [], 'local');
+
+    // Seed default "Favourites" collection when stored array is empty
+    const collections: Collection[] = rawCollections.length === 0 ? [DEFAULT_COLLECTION] : rawCollections;
+
+    const addCollection = (name: string) => {
+        if (!isValidName(name)) return;
+        const newCollection: Collection = {
+            id: crypto.randomUUID(),
+            name: name.trim(),
+            itemIds: [],
+        };
+        setCollections([...collections, newCollection]);
+    };
+
+    const removeCollection = (id: string) => {
+        setCollections(collections.filter(c => c.id !== id));
+    };
+
+    const renameCollection = (id: string, name: string) => {
+        if (!isValidName(name)) return;
+        setCollections(collections.map(c => c.id === id ? { ...c, name: name.trim() } : c));
+    };
+
+    const toggleBookmark = (collectionId: string, item: BrewItem) => {
+        setCollections(collections.map(c => {
+            if (c.id !== collectionId) return c;
+            const has = c.itemIds.includes(item.id);
+            return {
+                ...c,
+                itemIds: has
+                    ? c.itemIds.filter(id => id !== item.id)
+                    : [...c.itemIds, item.id],
+            };
+        }));
+    };
+
+    const isBookmarked = (itemId: string): boolean =>
+        collections.some(c => c.itemIds.includes(itemId));
+
+    const getCollectionForItem = (itemId: string): Collection | undefined =>
+        collections.find(c => c.itemIds.includes(itemId));
+
+    return (
+        <BookmarksContext.Provider value={{
+            collections,
+            addCollection,
+            removeCollection,
+            renameCollection,
+            toggleBookmark,
+            isBookmarked,
+            getCollectionForItem,
+        }}>
+            {children}
+        </BookmarksContext.Provider>
+    );
+}
+
+export function useBookmarks(): BookmarksContextType {
+    const ctx = useContext(BookmarksContext);
+    if (!ctx) throw new Error('useBookmarks must be used within a BookmarksProvider');
+    return ctx;
+}

--- a/src/components/contexts/RecentlyViewedContext.tsx
+++ b/src/components/contexts/RecentlyViewedContext.tsx
@@ -1,0 +1,96 @@
+/**
+ * @file RecentlyViewedContext.tsx
+ * Tracks recently viewed brew items with localStorage persistence and TTL.
+ */
+
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import type { BrewItem, BrewType } from '../../types';
+
+export interface RecentEntry {
+    id: string;
+    type: BrewType;
+    token: string;
+    name: string;
+    desc: string;
+    homepage?: string;
+}
+
+interface RecentlyViewedContextType {
+    recentItems: RecentEntry[];
+    trackView(item: BrewItem): void;
+    clearRecent(): void;
+}
+
+const MAX_RECENT = 10;
+const TTL_MS = 60 * 60 * 1000 * 24 * 3; // 3 day
+const STORAGE_KEY_ITEMS = 'brewlens_recent';
+const STORAGE_KEY_TIMESTAMP = 'brewlens_recent_ts';
+
+function loadRecentItems(): RecentEntry[] {
+    try {
+        const timestampRaw = localStorage.getItem(STORAGE_KEY_TIMESTAMP);
+        if (!timestampRaw) return [];
+
+        const timestamp = parseInt(timestampRaw, 10);
+        if (isNaN(timestamp) || Date.now() - timestamp > TTL_MS) {
+            // Expired or invalid timestamp, clear both storage entries
+            localStorage.removeItem(STORAGE_KEY_ITEMS);
+            localStorage.removeItem(STORAGE_KEY_TIMESTAMP);
+            return [];
+        }
+
+        const itemsRaw = localStorage.getItem(STORAGE_KEY_ITEMS);
+        if (!itemsRaw) return [];
+
+        const items = JSON.parse(itemsRaw) as RecentEntry[];
+        return Array.isArray(items) ? items : [];
+    } catch (error) {
+        console.error('Failed to load recent items from localStorage', error);
+        return [];
+    }
+}
+
+function persistRecentItems(items: RecentEntry[]) {
+    localStorage.setItem(STORAGE_KEY_ITEMS, JSON.stringify(items));
+    localStorage.setItem(STORAGE_KEY_TIMESTAMP, Date.now().toString());
+}
+
+const RecentlyViewedContext = createContext<RecentlyViewedContextType | null>(null);
+
+export function RecentlyViewedProvider({ children }: { children: ReactNode }) {
+    const [recentItems, setRecentItems] = useState<RecentEntry[]>(loadRecentItems);
+
+    // Persist to localStorage whenever the list changes
+    useEffect(() => {
+        persistRecentItems(recentItems);
+    }, [recentItems]);
+
+    const trackView = (item: BrewItem) => {
+        const entry: RecentEntry = {
+            id: item.id,
+            type: item.type,
+            token: item.token,
+            name: item.name,
+            desc: item.desc,
+            homepage: item.homepage,
+        };
+        setRecentItems(prev => {
+            const deduped = prev.filter(e => e.id !== entry.id);
+            return [entry, ...deduped].slice(0, MAX_RECENT);
+        });
+    };
+
+    const clearRecent = () => setRecentItems([]);
+
+    return (
+        <RecentlyViewedContext.Provider value={{ recentItems, trackView, clearRecent }}>
+            {children}
+        </RecentlyViewedContext.Provider>
+    );
+}
+
+export function useRecentlyViewed(): RecentlyViewedContextType {
+    const ctx = useContext(RecentlyViewedContext);
+    if (!ctx) throw new Error('useRecentlyViewed must be used within a RecentlyViewedProvider');
+    return ctx;
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Button } from "../ui/Button";
-import { MenuIcon, Moon, Sun, TrendingUp } from "lucide-react";
+import { MenuIcon, Moon, Sun, Grid } from "lucide-react";
 import { NavLink } from "react-router-dom";
 import logo from "../../assets/brewlens_logo.png"
 
@@ -25,7 +25,7 @@ export const Header: React.FC<HeaderProps> = ({ setIsOpen }) => {
   }
 
   return (
-    <header className="flex  gap-4 justify-between items-center">
+    <header className="flex  gap-4 flex-wrap justify-between items-center">
       <div className="flex items-center gap-3">
         <Button variant="ghost"
           onClick={() => setIsOpen(true)}
@@ -42,10 +42,10 @@ export const Header: React.FC<HeaderProps> = ({ setIsOpen }) => {
           </h1>
         </NavLink>
       </div>
-      <div className="flex gap-3">
-        <NavLink to="/analytics">
-          <Button variant="ghost" className="shrink-0">
-            <TrendingUp size={20} />
+      <div className="flex gap-2">
+        <NavLink to={`/all`}>
+          <Button variant="ghost" size="md">
+            <Grid size={18} /> <span className="text-sm font-medium">All Apps</span>
           </Button>
         </NavLink>
         <Button

--- a/src/components/page/Analytics.tsx
+++ b/src/components/page/Analytics.tsx
@@ -191,3 +191,7 @@ export default function Analytics() {
         </div>
     );
 }
+
+
+// Analytics.tsx (add exports at the bottom)
+export { fetchAnalytics, formatCount, fetchCaskMeta };

--- a/src/components/page/BrewList.tsx
+++ b/src/components/page/BrewList.tsx
@@ -10,7 +10,7 @@
  * - Quick search shortcuts via modal
  * - Paginated grid with localStorage page persistence per type
  */
-import React, { useState, useMemo, useEffect, useCallback, useDeferredValue } from "react";
+import React, { useState, useMemo, useEffect, useCallback, useDeferredValue, useRef } from "react";
 import { useBrewData } from "../../hooks/useBrewData";
 import { usePagination } from "../../hooks/usePagination";
 import { useStorage } from "../../hooks/useStorage";
@@ -25,6 +25,7 @@ import { Button } from "../ui/Button";
 import { useModal } from '../contexts/ModalContexts';
 import SearchIndexModal from "../ui/SearchIndexModal";
 import QuickSearchModal from "../ui/QuickSearchModal";
+import BookmarksModal from "../ui/BookmarksModal";
 
 
 interface Props {
@@ -35,9 +36,11 @@ interface Props {
 }
 
 export const BrewList: React.FC<Props> = ({ type, setType, search, setSearch }) => {
+    const searchInputRef = useRef<HTMLInputElement>(null);
     const [itemsPerPage, setItemsPerPage] = useState(24);
     const [newChar, setNewChar] = useState<string | null>(null);
-    const [filterArr, setFilterArr] = useStorage<string[]>('brewlist_filters', []);
+    const [isFocused, setIsFocused] = useState(false);
+    const [filterArr, setFilterArr] = useStorage<string[]>('brewlist_filters', ['active']);
     const activeFilters = new Set(filterArr);
     const setActiveFilters = (fn: Set<string> | ((prev: Set<string>) => Set<string>)) => {
         setFilterArr(prev => {
@@ -76,6 +79,7 @@ export const BrewList: React.FC<Props> = ({ type, setType, search, setSearch }) 
         // sort the data by name
         data.sort((a, b) => a.name.localeCompare(b.name));
         let result = data;
+        console.log(filterArr);
         if (deferredSearch) result = result.filter(i => i._searchString.includes(deferredSearch.toLowerCase()));
         if (activeFilters.has('oss')) result = result.filter(i => i.package.isFoss);
         if (activeFilters.has('proprietary')) result = result.filter(i => !i.package.isFoss);
@@ -88,6 +92,39 @@ export const BrewList: React.FC<Props> = ({ type, setType, search, setSearch }) 
     const pagination = usePagination(filtered, itemsPerPage, `cp_${type}`);
     const { currentData, setCurrentPage, totalPages } = pagination
 
+    useEffect(() => {
+        let lastEscTime = 0;
+        const handleKeyDown = (e: KeyboardEvent) => {
+            // 1. Clear search on Escape
+            if (e.key === 'Escape') {
+                const currentTime = Date.now();
+                setSearch("");
+                // 2. Check for double press (within 300ms)
+                if (currentTime - lastEscTime < 300) {
+                    // Exit focus from the input
+                    if (document.activeElement instanceof HTMLElement) {
+                        document.activeElement.blur();
+                    }
+                    console.log("removed focus")
+                }
+                lastEscTime = currentTime;
+            }
+
+            // 2. Focus on '/'
+            if (e.key === '/') {
+                // Optional: Don't hijack focus if user is already typing in an input
+                if (document.activeElement?.tagName === 'INPUT' || document.activeElement?.tagName === 'TEXTAREA') {
+                    return;
+                }
+
+                e.preventDefault(); // Prevents the "/" from appearing in the input
+                searchInputRef.current?.focus(); // Must use () to call the function
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [setSearch]);
 
     useEffect(() => {
         if (!newChar || newChar === '#') {
@@ -115,6 +152,12 @@ export const BrewList: React.FC<Props> = ({ type, setType, search, setSearch }) 
         openModal(() => <QuickSearchModal onSelect={setSearch} />, { closeOnBackdropClick: true });
     }, [setSearch]);
 
+    const handleBookmarkView = useCallback(() => {
+        openModal(() => <BookmarksModal />, { closeOnBackdropClick: true });
+    }, [setSearch]);
+
+
+
 
     const clearFilters = () => setActiveFilters(new Set());
 
@@ -124,18 +167,38 @@ export const BrewList: React.FC<Props> = ({ type, setType, search, setSearch }) 
     }
 
     {/* CONTROLS */ }
-   return <div className="container max-w-[1400px] mx-auto px-4">
+    return <div className="container max-w-[1400px] mx-auto px-4">
         <div className="flex w-full flex-wrap justify-between items-center gap-4 mb-8">
             <div className="flex flex-wrap gap-2 w-full sm:w-auto items-center">
                 <div className="relative w-full sm:w-auto sm:min-w-[16rem] sm:max-w-[20rem]">
                     <Search className="absolute left-3 top-3 text-gray-400" size={18} />
+
                     <input
-                        className="w-full pl-10 pr-10 py-2 rounded-lg bg-white dark:bg-zinc-800 border border-gray-200 dark:border-gray-700 focus:ring-2 focus:ring-green-500 outline-none"
-                        placeholder={`Search...`}
+                        ref={searchInputRef}
+                        className="w-full pl-10 pr-16 py-2 rounded-lg bg-white dark:bg-zinc-800 border border-gray-200 dark:border-gray-700 focus:ring-2 focus:ring-green-500 outline-none transition-all"
+                        placeholder="Search..."
                         value={search}
+                        onFocus={() => setIsFocused(true)}
+                        onBlur={() => setIsFocused(false)}
                         onChange={(e) => setSearch(e.target.value)}
                     />
-                    {search && <X className="absolute right-3 top-3 text-gray-400 bg-zinc-300/10 hover:bg-zinc-300 p-[2px] rounded-full cursor-pointer" size={18} onClick={() => setSearch("")} />}
+
+                    <div className="absolute right-3 top-2.5 flex items-center gap-2 cursor-pointer">
+                        {/* Shortcut Badges */}
+                        {!search && !isFocused && (
+                            <kbd className="hidden sm:inline-block px-1.5 py-0.5 text-[10px] font-medium text-gray-400 border border-gray-300 dark:border-zinc-600 rounded bg-gray-50 dark:bg-zinc-700">
+                                /
+                            </kbd>
+                        )}
+
+                        {search && (
+                            <kbd
+                                onClick={() => setSearch("")}
+                                className="hidden sm:inline-block px-1.5 py-0.5 text-[10px] font-medium text-gray-400 border border-gray-300 dark:border-zinc-600 rounded bg-gray-50 dark:bg-zinc-700">
+                                ESC
+                            </kbd>
+                        )}
+                    </div>
                 </div>
 
                 <Button variant="secondary" size="md" onClick={handleQuickSearch} title="Quick search">
@@ -155,8 +218,14 @@ export const BrewList: React.FC<Props> = ({ type, setType, search, setSearch }) 
                     ))}
                 </div>
             </div>
-
             <div className="px-1 flex gap-2">
+                <Button
+                    onClick={handleBookmarkView}
+                    variant="secondary"
+                    size="sm"
+                >
+                    Bookmarks
+                </Button>
                 <Button
                     onClick={handleOpenIndexSearch}
                     variant="secondary"
@@ -198,29 +267,29 @@ export const BrewList: React.FC<Props> = ({ type, setType, search, setSearch }) 
             </div>
 
 
-        <div className="quick-action-right">
-            {type === 'cask' && (
-                <>
-                    {/* <span className="text-gray-300 dark:text-zinc-600">|</span> */}
-                    <label className="flex items-center gap-2 mr-6 cursor-pointer select-none text-xs text-zinc-500 dark:text-zinc-400">
-                        <span>Fonts</span>
-                        <div
-                            onClick={() => setShowFonts(p => !p)}
-                            className={cn(
-                                "relative w-8 h-4 rounded-full transition-colors duration-200",
-                                showFonts ? "bg-green-500" : "bg-zinc-300 dark:bg-zinc-600"
-                            )}
-                        >
-                            <div className={cn(
-                                "absolute top-0.5 w-3 h-3 rounded-full bg-white shadow transition-transform duration-200",
-                                showFonts ? "translate-x-4" : "translate-x-0.5"
-                            )} />
-                        </div>
-                    </label>
-                </>
-            )}
+            <div className="quick-action-right">
+                {type === 'cask' && (
+                    <>
+                        {/* <span className="text-gray-300 dark:text-zinc-600">|</span> */}
+                        <label className="flex items-center gap-2 mr-6 cursor-pointer select-none text-xs text-zinc-500 dark:text-zinc-400">
+                            <span>Fonts</span>
+                            <div
+                                onClick={() => setShowFonts(p => !p)}
+                                className={cn(
+                                    "relative w-8 h-4 rounded-full transition-colors duration-200",
+                                    showFonts ? "bg-green-500" : "bg-zinc-300 dark:bg-zinc-600"
+                                )}
+                            >
+                                <div className={cn(
+                                    "absolute top-0.5 w-3 h-3 rounded-full bg-white shadow transition-transform duration-200",
+                                    showFonts ? "translate-x-4" : "translate-x-0.5"
+                                )} />
+                            </div>
+                        </label>
+                    </>
+                )}
+            </div>
         </div>
-                </div>
 
         {/* GRID */}
         {isLoading && <SkeletonGrid count={itemsPerPage} />}

--- a/src/components/page/CaskDetail.tsx
+++ b/src/components/page/CaskDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useBrewData } from "../../hooks/useBrewData";
 import { type BrewItem, type BrewType } from "../../types";
 import { useLocation } from "react-router-dom";
@@ -6,8 +6,10 @@ import { ExternalLink, Box, Zap, Trash2, Info, Check, Clipboard, InfoIcon, Wrenc
 import { Share2, ChevronLeft } from 'lucide-react';
 import { NavLink } from "react-router-dom";
 import { Button } from "../ui/Button";
+import { BookmarkButton } from "../ui/BookmarkButton";
 import SkeletonDetails from "./SkeletonDetails";
 import { getSourceCodeStatus } from "../../lib/utils";
+import { useRecentlyViewed } from "../contexts/RecentlyViewedContext";
 
 /**
  * Formats an artifact value for display.
@@ -28,6 +30,7 @@ function formatArtifactValue(value: unknown): string {
 export function CaskDetail() {
   const [copied, setCopied] = useState({ installCmd: false, appLink: false });
   const location = useLocation();
+  const { trackView } = useRecentlyViewed();
 
   const pathSegments = location.pathname.split('/');
   const token = pathSegments[pathSegments.length - 1];
@@ -37,6 +40,10 @@ export function CaskDetail() {
   const { data = [], isLoading, error } = useBrewData(type, url);
 
   const item: BrewItem = data[0];
+
+  useEffect(() => {
+    if (item) trackView(item);
+  }, [item?.id]);
 
   const packageStatus = (item: BrewItem) => {
     const isNotInstallable = (item.deprecated || item.disabled);
@@ -118,6 +125,7 @@ export function CaskDetail() {
 
         {/* Header Action Buttons */}
         <div className="flex gap-2 text-zinc-400">
+          <BookmarkButton item={item} size="sm" />
           <Button
             onClick={() => copyURL()}
             variant="ghost"

--- a/src/components/page/CaskDetail.tsx
+++ b/src/components/page/CaskDetail.tsx
@@ -26,7 +26,7 @@ function formatArtifactValue(value: unknown): string {
 }
 
 export function CaskDetail() {
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState({ installCmd: false, appLink: false });
   const location = useLocation();
 
   const pathSegments = location.pathname.split('/');
@@ -47,14 +47,14 @@ export function CaskDetail() {
 
   const copyCmd = (item: BrewItem) => {
     navigator.clipboard.writeText(item.installCmd);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    setCopied({ installCmd: true, appLink: false });
+    setTimeout(() => setCopied({ installCmd: false, appLink: false }), 1500);
   };
 
   const copyURL = () => {
-    navigator.clipboard.writeText(url);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    navigator.clipboard.writeText(window.location.href);
+    setCopied({ installCmd: false, appLink: true });
+    setTimeout(() => setCopied({ installCmd: false, appLink: false }), 1500);
   };
 
 
@@ -123,7 +123,7 @@ export function CaskDetail() {
             variant="ghost"
             size="sm"
           >
-            {copied ? <Check size={18} /> : <Share2 size={18} />}
+            {copied.appLink ? <Check size={18} /> : <Share2 size={18} />}
           </Button>
           <a
             href={url}
@@ -173,7 +173,7 @@ export function CaskDetail() {
                   variant="glass"
                   size="icon"
                   className="absolute right-[0.15rem] top-[0.15rem] z-10 text-zinc-200 hover:text-zinc-100 px-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all" >
-                  {copied ? <Check className="w-4 h-4" /> : <Clipboard className="w-4 h-4" />}
+                  {copied.installCmd ? <Check className="w-4 h-4" /> : <Clipboard className="w-4 h-4" />}
                 </Button>
               </div>
 
@@ -194,7 +194,7 @@ export function CaskDetail() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Button variant="glass"    >
+                <Button variant="glass" className="text-zinc-200" >
                   <Code size={20} />Source
                 </Button>
               </a>}

--- a/src/components/page/Dashboard.tsx
+++ b/src/components/page/Dashboard.tsx
@@ -1,0 +1,313 @@
+import { ItemCard } from "../ItemCard";
+import RecentlyViewedStrip from "../ui/RecentlyViewedStrip";
+import { useState, useEffect, useCallback } from 'react';
+import { useBrewData } from "../../hooks/useBrewData";
+import { Button } from "../ui/Button";
+import { NavLink } from "react-router-dom";
+import { useRecentlyViewed } from '../contexts/RecentlyViewedContext';
+import { type BrewItem } from '../../types';
+import { RefreshCcw, Grid, BrushCleaning } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchAnalytics, formatCount, fetchCaskMeta } from "../page/Analytics"; // adjust path
+import { TrendingUp } from "lucide-react";
+
+
+const STORAGE_KEY = "dashboard_random_picks";
+const TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface StoredPicks {
+    indices: number[];
+    timestamp: number;
+}
+
+const Dashboard = () => {
+    let { data, isLoading, error } = useBrewData("cask");
+    const [randomPicks, setRandomPicks] = useState<BrewItem[]>([]);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const { recentItems, clearRecent } = useRecentlyViewed();
+    const [filteredData, setFilteredData] = useState<BrewItem[]>(data ?? []);
+
+    useEffect(() => {
+        if (isLoading) return;
+        else if (error) return;
+        else {
+            let fdata = data?.filter(i => !i.deprecated && !i.disabled) || [];
+            fdata = fdata.filter(i => !i.token.startsWith('font-'));
+            setFilteredData(fdata);
+        }
+    }, [data, isLoading]);
+
+
+    // Analytics section query
+    const { data: analytics30d, isLoading: isLoadingAnalytics, error: analyticsError } = useQuery({
+        queryKey: ['analytics', '30d'],
+        queryFn: () => fetchAnalytics('30d'),
+        staleTime: 1000 * 60 * 10,
+    });
+
+    const { data: caskMeta = {} } = useQuery({
+        queryKey: ['cask-meta'],
+        queryFn: fetchCaskMeta,
+        staleTime: 1000 * 60 * 60,
+    });
+
+    const topItems = analytics30d?.items?.slice(0, 5) ?? [];
+    const maxCount = topItems[0] ? parseInt(topItems[0].count.replace(/,/g, ''), 10) : 1;
+    const totalFormatted = analytics30d ? formatCount(String(analytics30d.total_count)) : null;
+
+
+    // Generate new random picks (indices only) based on current data
+    const generateRandomIndices = useCallback((): number[] => {
+
+        if (!filteredData.length) return [];
+        const dataLen = filteredData.length;
+        const numPicks = Math.min(8, dataLen);
+        const indicesSet = new Set<number>();
+        while (indicesSet.size < numPicks) {
+            indicesSet.add(Math.floor(Math.random() * dataLen));
+        }
+        return Array.from(indicesSet);
+    }, [filteredData]);
+
+    // Store indices and timestamp to localStorage
+    const storePicks = useCallback((indices: number[]) => {
+        const stored: StoredPicks = {
+            indices,
+            timestamp: Date.now(),
+        };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+    }, []);
+
+    // Load stored picks and map them to actual BrewItems
+    const loadStoredPicks = useCallback((): BrewItem[] => {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return [];
+
+        try {
+            const stored: StoredPicks = JSON.parse(raw);
+            const now = Date.now();
+            if (now - stored.timestamp > TTL_MS) {
+                // Expired
+                return [];
+            }
+
+            // Map indices to actual data items, filter out any that are out of bounds
+            const items = stored.indices
+                .map(idx => filteredData[idx])
+                .filter((item): item is BrewItem => item !== undefined);
+
+            return items;
+        } catch (e) {
+            console.error("Failed to parse stored picks", e);
+            return [];
+        }
+    }, [filteredData]);
+
+    // Refresh random picks (manual or automatic)
+    const refreshRandomPicks = useCallback(async () => {
+        if (isLoading || !filteredData.length) return;
+
+        setIsRefreshing(true);
+        try {
+            const newIndices = generateRandomIndices();
+            if (newIndices.length) {
+                const newPicks = newIndices.map(idx => filteredData[idx]);
+                setRandomPicks(newPicks);
+                storePicks(newIndices);
+            } else {
+                setRandomPicks([]);
+            }
+        } finally {
+            setIsRefreshing(false);
+        }
+    }, [filteredData, isLoading, generateRandomIndices, storePicks]);
+
+    // Initial load and data changes: decide whether to use stored or generate fresh
+    useEffect(() => {
+
+        if (isLoading || !filteredData.length) return;
+
+        const storedItems = loadStoredPicks();
+        if (storedItems.length) {
+            setRandomPicks(storedItems);
+        } else {
+            // No valid stored picks, generate fresh
+            refreshRandomPicks();
+        }
+    }, [filteredData, isLoading, loadStoredPicks, refreshRandomPicks]);
+
+    // Auto-refresh: check every minute if the stored picks are expired, and refresh if needed
+    useEffect(() => {
+        if (isLoading) return; // Wait for data to load
+
+        const intervalId = setInterval(() => {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (!raw) return;
+
+            try {
+                const stored: StoredPicks = JSON.parse(raw);
+                const now = Date.now();
+                if (now - stored.timestamp >= TTL_MS) {
+                    // Expired, refresh
+                    refreshRandomPicks();
+                }
+            } catch (e) {
+                console.error("Failed to parse stored picks in interval", e);
+            }
+        }, 60000); // check every minute
+
+        return () => clearInterval(intervalId);
+    }, [isLoading, refreshRandomPicks]);
+
+    return (
+        <div className="sections flex flex-col gap-4 transition-all duration-500 px-4">
+            {/* Recently Viewed Section */}
+            {recentItems && recentItems.length > 0 && (
+                <div className="section bg-gradient-to-br from-cyan-400/10 via-blue-500/5 to-transparent dark:from-cyan-500/10 dark:via-blue-600/10 dark:to-transparent border border-cyan-200/30 dark:border-cyan-700/20 shadow-md rounded-xl p-4 backdrop-blur-sm transition-all duration-500 hover:shadow-lg">
+                    <div className="header flex justify-between items-center text-md text-zinc-900 dark:text-zinc-300 mb-2">
+                        <div className="title">
+                            <span className="bg-cyan-700 mr-3 text-cyan-700 rounded-xs">|</span>
+                            Recently Viewed
+                        </div>
+                        <div className="action">
+                            <Button variant="ghost" size="sm" onClick={() => clearRecent()}>
+                                <BrushCleaning size={18} /> <span className="text-sm font-medium">Clear Recents</span>
+                            </Button>
+                        </div>
+                    </div>
+                    <div className="contents">
+                        <RecentlyViewedStrip />
+                    </div>
+                </div>
+            )}
+
+            {/* Random Picks Section */}
+            <div className="section bg-gradient-to-br from-purple-400/10 via-pink-500/5 to-transparent dark:from-purple-600/10 dark:via-pink-700/8 dark:to-transparent border border-purple-200/30 dark:border-purple-700/10 shadow-md rounded-xl p-4 transition-all duration-500 hover:shadow-lg">
+                <div className="header flex justify-between items-center text-md text-zinc-900 dark:text-zinc-300 mb-2">
+                    <div className="title">
+                        <span className="bg-purple-700 mr-3 text-purple-700 rounded-xs">|</span>
+                        Random Picks
+                    </div>
+                    <div className="action flex gap-2">
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={refreshRandomPicks}
+                            disabled={isRefreshing || isLoading}
+                        >
+                            <span className="text-sm font-medium flex gap-2">
+                                <RefreshCcw size={18} /> {isRefreshing ? "Refreshing..." : "Refresh"}
+                            </span>
+                        </Button>
+                        <NavLink to={`/all`}>
+                            <Button variant="ghost" size="sm">
+                                <Grid size={18} /> <span className="text-sm font-medium">All Apps</span>
+                            </Button>
+                        </NavLink>
+                    </div>
+                </div>
+                <div className="contents">
+                    {isLoading && <p>Loading random picks...</p>}
+                    {!isLoading && randomPicks.length > 0 && (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                            {randomPicks.map((item) => (
+                                <ItemCard key={item.id} item={item} />
+                            ))}
+                        </div>
+                    )}
+                    {!isLoading && randomPicks.length === 0 && filteredData.length > 0 && (
+                        <p>No items to display.</p>
+                    )}
+                </div>
+            </div>
+
+            {/* Analytics Section – Top 5 Casks (30 Days) */}
+            <div className="section bg-gradient-to-br from-amber-400/10 via-orange-500/5 to-transparent dark:from-amber-500/10 dark:via-orange-600/10 dark:to-transparent border border-amber-200/30 dark:border-amber-700/20 shadow-md rounded-xl p-4 transition-all duration-500 hover:shadow-lg">
+                <div className="header flex justify-between items-center text-md text-zinc-900 dark:text-zinc-300 mb-2">
+                    <div className="title">
+                        <span className="bg-amber-700 mr-3 text-amber-700 rounded-xs">|</span>
+                        Top Casks – Last 30 Days
+                        {totalFormatted && (
+                            <span className="text-xs text-zinc-500 ml-2">
+                                (Total: {totalFormatted})
+                            </span>
+                        )}
+                    </div>
+                    <div className="action">
+                        <NavLink to="/analytics">
+                            <Button variant="ghost" size="sm">
+                                <TrendingUp size={18} />
+                                <span className="text-sm font-medium">View Full Analytics</span>
+                            </Button>
+                        </NavLink>
+                    </div>
+                </div>
+                <div className="contents">
+                    {isLoadingAnalytics && (
+                        <div className="space-y-3">
+                            {Array.from({ length: 5 }).map((_, i) => (
+                                <div key={i} className="h-14 rounded-xl bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+                            ))}
+                        </div>
+                    )}
+                    {analyticsError && (
+                        <p className="text-red-500 text-sm">Failed to load analytics data.</p>
+                    )}
+                    {!isLoadingAnalytics && !analyticsError && topItems.length === 0 && (
+                        <p className="text-zinc-500 text-sm">No data available.</p>
+                    )}
+                    {!isLoadingAnalytics && !analyticsError && topItems.length > 0 && (
+                        <div className="space-y-2">
+                            {topItems.map((item) => {
+                                const homepage = caskMeta[item.cask];
+                                const count = parseInt(item.count.replace(/,/g, ''), 10);
+                                const barWidth = Math.max(2, (count / maxCount) * 100);
+
+                                return (
+                                    <NavLink key={item.cask} to={`/cask/${item.cask}`}>
+                                        <div className="flex flex-wrap items-center gap-2 sm:gap-4 px-4 py-3 my-1 rounded-xl bg-white dark:bg-zinc-900 border border-gray-100 dark:border-zinc-800 hover:border-amber-500 transition-all cursor-pointer">
+                                            {/* Rank */}
+                                            <span className="w-6 text-xs text-zinc-400 text-right shrink-0">{item.number}.</span>
+
+                                            {/* Favicon */}
+                                            <img
+                                                src={`https://www.google.com/s2/favicons?domain=${homepage}&sz=32`}
+                                                onError={(e) => (e.currentTarget.src = '/vite.svg')}
+                                                className="w-6 h-6 rounded shrink-0"
+                                                alt=""
+                                            />
+
+                                            {/* Cask name – takes remaining space, truncates */}
+                                            <span className="flex-1 min-w-0 text-sm font-medium truncate">{item.cask}</span>
+
+                                            {/* Count and percentage: on mobile combine them, on large show count only */}
+                                            <span className="text-xs text-zinc-500 shrink-0 text-right">
+                                                <span className="sm:hidden">{formatCount(item.count)} ({item.percent}%)</span>
+                                                <span className="hidden sm:inline">{formatCount(item.count)}</span>
+                                            </span>
+
+                                            {/* Bar – full width on mobile, flexible on larger screens */}
+                                            <div className="w-full sm:flex-1 h-2 bg-zinc-100 dark:bg-zinc-800 rounded-full overflow-hidden mt-1 sm:mt-0">
+                                                <div
+                                                    className="h-full rounded-full transition-all duration-500 bg-gradient-to-r from-amber-400/40 via-orange-500/70 to-orange-500/70"
+                                                    style={{ width: `${barWidth}%` }}
+                                                />
+                                            </div>
+
+                                            {/* Percentage column – only visible on larger screens */}
+                                            <span className="hidden sm:block w-12 text-xs font-semibold text-zinc-500 text-right shrink-0">
+                                                {item.percent}%
+                                            </span>
+                                        </div>
+                                    </NavLink>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default Dashboard;

--- a/src/components/page/FormulaeDetail.tsx
+++ b/src/components/page/FormulaeDetail.tsx
@@ -28,7 +28,7 @@ export const Tag = ({ label }: { label: string | null }) => {
 
 
 export const FormulaeDetail = () => {
-    const [copied, setCopied] = useState(false);
+    const [copied, setCopied] = useState({ installCmd: false, appLink: false });
     const location = useLocation();
 
     const pathSegments = location.pathname.split('/');
@@ -77,14 +77,14 @@ export const FormulaeDetail = () => {
 
     const copyCmd = (item: BrewItem) => {
         navigator.clipboard.writeText(item.installCmd);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        setCopied({ installCmd: true, appLink: false });
+        setTimeout(() => setCopied({ installCmd: false, appLink: false }), 1500);
     };
 
     const copyURL = () => {
-        navigator.clipboard.writeText(url);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        navigator.clipboard.writeText(window.location.href);
+        setCopied({ installCmd: false, appLink: true });
+        setTimeout(() => setCopied({ installCmd: false, appLink: false }), 1500);
     };
 
     let monthly = item.raw.analytics.install["30d"][item.token];
@@ -127,7 +127,7 @@ export const FormulaeDetail = () => {
                             variant="ghost"
                             size="sm"
                         >
-                            {copied ? <Check size={18} /> : <Share2 size={18} />}
+                            {copied.appLink ? <Check size={18} /> : <Share2 size={18} />}
                         </Button>
                         <a
                             href={url}
@@ -174,7 +174,7 @@ export const FormulaeDetail = () => {
                                         variant="glass"
                                         size="icon"
                                         className="absolute right-[0.15rem] top-[0.15rem] z-10 text-zinc-200 hover:text-zinc-100 px-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all" >
-                                        {copied ? <Check className="w-4 h-4" /> : <Clipboard className="w-4 h-4" />}
+                                        {copied.installCmd ? <Check className="w-4 h-4" /> : <Clipboard className="w-4 h-4" />}
                                     </Button>
                                 </div>
                             </div>
@@ -195,7 +195,7 @@ export const FormulaeDetail = () => {
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >
-                                <Button variant="glass"    >
+                                <Button variant="glass" className="text-zinc-100" >
                                     <Code size={20} />Source
                                 </Button>
                             </a>}

--- a/src/components/page/FormulaeDetail.tsx
+++ b/src/components/page/FormulaeDetail.tsx
@@ -1,13 +1,15 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useLocation } from 'react-router-dom';
 import { useBrewData } from "../../hooks/useBrewData";
 import { ExternalLink, Info, Share2, ChevronLeft, Check, Clipboard, Box, Download, Code } from 'lucide-react';
 import type { BrewItem, BrewType } from '../../types';
 import { NavLink } from "react-router-dom";
 import { Button } from "../ui/Button";
+import { BookmarkButton } from "../ui/BookmarkButton";
 import { cn } from "../../lib/utils";
 import SkeletonDetails from "./SkeletonDetails";
 import { getSourceCodeStatus } from "../../lib/utils";
+import { useRecentlyViewed } from "../contexts/RecentlyViewedContext";
 
 
 export const Tag = ({ label }: { label: string | null }) => {
@@ -30,6 +32,7 @@ export const Tag = ({ label }: { label: string | null }) => {
 export const FormulaeDetail = () => {
     const [copied, setCopied] = useState({ installCmd: false, appLink: false });
     const location = useLocation();
+    const { trackView } = useRecentlyViewed();
 
     const pathSegments = location.pathname.split('/');
     const token = pathSegments[pathSegments.length - 1];
@@ -39,6 +42,10 @@ export const FormulaeDetail = () => {
     const { data = [], isLoading, error } = useBrewData(type, url);
 
     const item: BrewItem = data[0];
+
+    useEffect(() => {
+        if (item) trackView(item);
+    }, [item?.id]);
 
 
     if (!item) {
@@ -122,6 +129,7 @@ export const FormulaeDetail = () => {
                     </NavLink>
                     {/* Header Action Buttons */}
                     <div className="flex gap-2 text-zinc-400">
+                        <BookmarkButton item={item} size="sm" />
                         <Button
                             onClick={() => copyURL()}
                             variant="ghost"

--- a/src/components/ui/BookmarkButton.tsx
+++ b/src/components/ui/BookmarkButton.tsx
@@ -1,0 +1,32 @@
+/**
+ * @file BookmarkButton.tsx
+ * A toggle button that bookmarks/unbookmarks a BrewItem into the 'favourites' collection.
+ */
+
+import { Bookmark } from 'lucide-react';
+import { Button } from './Button';
+import { useBookmarks } from '../contexts/BookmarksContext';
+import type { BrewItem } from '../../types';
+
+interface BookmarkButtonProps {
+    item: BrewItem;
+    size?: 'sm' | 'md';
+}
+
+export function BookmarkButton({ item, size = 'md' }: BookmarkButtonProps) {
+    const { isBookmarked, toggleBookmark } = useBookmarks();
+    const bookmarked = isBookmarked(item.id);
+
+    return (
+        <Button
+            variant="ghost"
+            size={size}
+            onClick={() => toggleBookmark('favourites', item)}
+            aria-label={bookmarked ? 'Remove bookmark' : 'Add bookmark'}
+        >
+            <Bookmark
+                className={bookmarked ? 'fill-current' : undefined}
+            />
+        </Button>
+    );
+}

--- a/src/components/ui/BookmarksModal.tsx
+++ b/src/components/ui/BookmarksModal.tsx
@@ -1,0 +1,197 @@
+/**
+ * @file BookmarksModal.tsx
+ * Management UI for bookmark collections.
+ * Allows creating, renaming, and deleting collections.
+ */
+import { useState, useRef, useEffect } from 'react';
+import { Trash2, Pencil, Check, X, BookmarkIcon } from 'lucide-react';
+import { useBookmarks } from '../contexts/BookmarksContext';
+import { useModal } from '../contexts/ModalContexts';
+import { Button } from './Button';
+import BrewfileModal from './BrewfileModal';
+import type { Collection } from '../contexts/BookmarksContext';
+import type { BrewItem, BrewType } from '../../types';
+
+export default function BookmarksModal() {
+    const { collections, addCollection, removeCollection, renameCollection } = useBookmarks();
+    const { openModal } = useModal();
+
+    const [newName, setNewName] = useState('');
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [editingName, setEditingName] = useState('');
+    const editInputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (editingId && editInputRef.current) {
+            editInputRef.current.focus();
+            editInputRef.current.select();
+        }
+    }, [editingId]);
+
+    const handleAdd = () => {
+        const trimmed = newName.trim();
+        if (!trimmed) return;
+        addCollection(trimmed);
+        setNewName('');
+    };
+
+    const handleAddKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') handleAdd();
+    };
+
+    const startEdit = (collection: Collection) => {
+        setEditingId(collection.id);
+        setEditingName(collection.name);
+    };
+
+    const commitEdit = () => {
+        if (editingId && editingName.trim()) {
+            renameCollection(editingId, editingName.trim());
+        }
+        setEditingId(null);
+        setEditingName('');
+    };
+
+    const cancelEdit = () => {
+        setEditingId(null);
+        setEditingName('');
+    };
+
+    const handleEditKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') commitEdit();
+        if (e.key === 'Escape') cancelEdit();
+    };
+
+    const handleGenerateBrewfile = () => {
+        // Collect all bookmarked item IDs across all collections.
+        // TODO: store BrewType alongside itemId in Collection to avoid defaulting to 'cask'.
+        const allItems: BrewItem[] = collections
+            .flatMap(c => c.itemIds)
+            .filter((id, idx, arr) => arr.indexOf(id) === idx) // deduplicate
+            .map(id => ({ id, token: id, type: 'cask' as BrewType, name: id, desc: '', version: '', installCmd: '', package: { verified: false, isFoss: false, fossUrl: null }, raw: {}, _searchString: '' }));
+
+        openModal(() => <BrewfileModal items={allItems} />, { size: 'md' });
+    };
+
+    return (
+        <div className="p-5 w-full max-w-md min-w-[20rem]">
+            <div className="flex items-center gap-2 mb-1">
+                <BookmarkIcon className="h-5 w-5 text-green-600 dark:text-green-500" />
+                <h2 className="text-lg font-bold text-zinc-900 dark:text-zinc-100">Collections</h2>
+            </div>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-4">
+                Manage your bookmark collections
+            </p>
+
+            {/* Collection list */}
+            <ul className="space-y-1 mb-4">
+                {collections.map((col) => (
+                    <li
+                        key={col.id}
+                        className="flex items-center gap-2 px-3 py-2 rounded-md bg-zinc-50 dark:bg-zinc-800/60 group"
+                    >
+                        {editingId === col.id ? (
+                            <>
+                                <input
+                                    ref={editInputRef}
+                                    value={editingName}
+                                    onChange={(e) => setEditingName(e.target.value)}
+                                    onKeyDown={handleEditKeyDown}
+                                    className="flex-1 text-sm bg-transparent border-b border-zinc-400 dark:border-zinc-500 outline-none text-zinc-900 dark:text-zinc-100"
+                                />
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={commitEdit}
+                                    aria-label="Confirm rename"
+                                    className="h-7 w-7 text-green-600 dark:text-green-500"
+                                >
+                                    <Check className="h-4 w-4" />
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={cancelEdit}
+                                    aria-label="Cancel rename"
+                                    className="h-7 w-7"
+                                >
+                                    <X className="h-4 w-4" />
+                                </Button>
+                            </>
+                        ) : (
+                            <>
+                                <button
+                                    onClick={() => startEdit(col)}
+                                    className="flex-1 text-left text-sm font-medium text-zinc-800 dark:text-zinc-200 hover:text-green-600 dark:hover:text-green-400 transition-colors truncate"
+                                    title="Click to rename"
+                                >
+                                    {col.name}
+                                </button>
+                                <span className="text-xs text-zinc-400 dark:text-zinc-500 shrink-0">
+                                    {col.itemIds.length} {col.itemIds.length === 1 ? 'item' : 'items'}
+                                </span>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={() => startEdit(col)}
+                                    aria-label={`Rename ${col.name}`}
+                                    className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                                >
+                                    <Pencil className="h-3.5 w-3.5" />
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={() => removeCollection(col.id)}
+                                    aria-label={`Delete ${col.name}`}
+                                    className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity text-red-500 hover:text-red-600 dark:text-red-400"
+                                >
+                                    <Trash2 className="h-3.5 w-3.5" />
+                                </Button>
+                            </>
+                        )}
+                    </li>
+                ))}
+                {collections.length === 0 && (
+                    <li className="text-sm text-zinc-400 dark:text-zinc-500 text-center py-4">
+                        No collections yet
+                    </li>
+                )}
+            </ul>
+
+            {/* Add new collection */}
+            <div className="flex gap-2 mb-5">
+                <input
+                    type="text"
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    onKeyDown={handleAddKeyDown}
+                    placeholder="New collection name…"
+                    maxLength={50}
+                    className="flex-1 h-9 px-3 text-sm rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                />
+                <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={handleAdd}
+                    disabled={!newName.trim()}
+                >
+                    Add
+                </Button>
+            </div>
+
+            {/* Footer */}
+            <div className="border-t border-zinc-200 dark:border-zinc-700 pt-4">
+                <Button
+                    variant="secondary"
+                    size="md"
+                    className="w-full"
+                    onClick={handleGenerateBrewfile}
+                    title="Full Brewfile generation coming in a future update"
+                >
+                    View Bookmarks
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/ui/BrewfileModal.tsx
+++ b/src/components/ui/BrewfileModal.tsx
@@ -1,0 +1,56 @@
+/**
+ * @file BrewfileModal.tsx
+ * Displays generated Brewfile content for a list of BrewItems.
+ * Provides a copy-to-clipboard button with transient feedback.
+ */
+import { useState } from 'react';
+import { FileText } from 'lucide-react';
+import { buildBrewfile } from '../../lib/brewfile';
+import { Button } from './Button';
+import type { BrewItem } from '../../types';
+
+interface BrewfileModalProps {
+    items: BrewItem[];
+}
+
+export default function BrewfileModal({ items }: BrewfileModalProps) {
+    const [copied, setCopied] = useState(false);
+    const content = buildBrewfile(items);
+
+    const handleCopy = async () => {
+        await navigator.clipboard.writeText(content);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+    };
+
+    return (
+        <div className="p-5 w-full max-w-lg min-w-[20rem]">
+            <div className="flex items-center justify-between mb-1">
+                <div className="flex items-center gap-2">
+                    <FileText className="h-5 w-5 text-green-600 dark:text-green-500" />
+                    <h2 className="text-lg font-bold text-zinc-900 dark:text-zinc-100">Bookmarks</h2>
+                </div>
+                <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                    {items.length} {items.length === 1 ? 'item' : 'items'}
+                </span>
+            </div>
+            {/* <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-4">
+                Copy and save as <code className="font-mono">Bookmarks</code> to restore with <code className="font-mono">brew bundle</code>
+            </p> */}
+
+            <pre className="font-mono text-sm bg-zinc-950 text-green-400 rounded-md p-4 overflow-auto max-h-72 mb-4 whitespace-pre">
+                {content || '# No items bookmarked'}
+            </pre>
+
+            <Button
+                variant="primary"
+                size="md"
+                className="w-full"
+                onClick={handleCopy}
+                disabled={items.length === 0}
+            >
+                {copied ? 'Copied ✓' : 'Copy to Clipboard'}
+            </Button>
+        </div>
+    );
+}

--- a/src/components/ui/RecentlyViewedStrip.tsx
+++ b/src/components/ui/RecentlyViewedStrip.tsx
@@ -1,0 +1,52 @@
+/**
+ * @file RecentlyViewedStrip.tsx
+ * Horizontally scrollable strip of recently viewed brew items.
+ */
+import { NavLink } from 'react-router-dom';
+import { useRecentlyViewed } from '../contexts/RecentlyViewedContext';
+
+interface RecentlyViewedStripProps {
+    maxVisible?: number;
+}
+
+export default function RecentlyViewedStrip({ maxVisible = 10 }: RecentlyViewedStripProps) {
+    const { recentItems } = useRecentlyViewed();
+
+    if (recentItems.length === 0) return null;
+
+    const visible = recentItems.slice(0, maxVisible);
+
+    return (
+        <div className="flex-1 flex flex-wrap gap-4 scrollbar-none">
+            {visible.map((item) => (
+                <NavLink
+                    key={item.id}
+                    to={`/${item.type}/${item.token}`}
+                    className="shrink-0 gap-2 px-3 py-3  w-57 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/40 hover:border-green-500 hover:bg-green-50 dark:hover:bg-green-900/20 transition-all"
+                    title={item.name}
+                >
+                    <div className="upper flex items-center gap-2">
+                        <img
+                            src={`https://www.google.com/s2/favicons?domain=${item.homepage}&sz=32`}
+                            onError={(e) => (e.currentTarget.src = '/vite.svg')}
+                            className="w-6 h-6 rounded-sm shrink-0"
+                            alt=""
+                        />
+                        <span className="text-sm font-medium text-zinc-800 dark:text-zinc-200 truncate flex-1">
+                            {item.name}
+                        </span>
+                        <span className="shrink-0 text-[10px] px-1 py-0.5 rounded bg-zinc-200 dark:bg-zinc-700 text-zinc-500 dark:text-zinc-400 uppercase">
+                            {item.type === 'cask' ? 'cask' : 'fml'}
+                        </span>
+                    </div>
+                    <div className="lower pt-2">
+                        <span className="text-sm text-zinc-800 dark:text-zinc-400 line-clamp-2">
+                            {item.desc}
+                        </span>
+                    </div>
+                </NavLink>
+            ))}
+        </div>
+
+    );
+}

--- a/src/lib/brewfile.ts
+++ b/src/lib/brewfile.ts
@@ -1,0 +1,11 @@
+import type { BrewItem } from '../types';
+
+/**
+ * Generates Brewfile content from a list of BrewItems.
+ * Casks emit `cask "token"`, formulae emit `brew "token"`.
+ */
+export function buildBrewfile(items: BrewItem[]): string {
+    return items
+        .map(item => item.type === 'cask' ? `cask "${item.token}"` : `brew "${item.token}"`)
+        .join('\n');
+}


### PR DESCRIPTION
Introduce bookmarking and recently-viewed features plus a new Dashboard and Brewfile generator. Added BookmarksContext and RecentlyViewedContext with localStorage persistence and TTL, BookmarkButton, BookmarksModal, BrewfileModal, RecentlyViewedStrip, and a small lib function (buildBrewfile). Integrated providers into App and wired BookmarkButton into Cask/Formula detail pages and RecentlyViewed tracking. Added Dashboard page showing recent items, random picks (cached in localStorage with TTL), and top analytics; updated BrewList with keyboard shortcuts, search input improvements, bookmark modal trigger, and various UI tweaks (Header, ItemCard styles). Also minor .gitignore update and export additions in Analytics.